### PR TITLE
Do not pass security headers to Kernel

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,10 @@ val http4sVersion   = "0.23.7"
 val natchezVersion  = "0.1.6"
 val scala212Version = "2.12.12"
 val scala213Version = "2.13.5"
-val scala3Version  = "3.1.0"
+val scala3Version   = "3.1.0"
 val slf4jVersion    = "1.7.30"
+val munitVersion    = "0.7.29"
+val munitCEVersion  = "1.0.7"
 
 // Global Settings
 lazy val commonSettings = Seq(
@@ -26,6 +28,14 @@ lazy val commonSettings = Seq(
        |""".stripMargin
     )
   ),
+
+  // Testing
+  libraryDependencies ++= Seq(
+    "org.scalameta" %%% "munit"               % munitVersion   % Test,
+    "org.typelevel" %%% "munit-cats-effect-3" % munitCEVersion % Test,
+    "org.http4s"    %%% "http4s-dsl"          % http4sVersion  % Test,
+  ),
+  testFrameworks += new TestFramework("munit.Framework"),
 
   // Compilation
   scalaVersion       := scala213Version,

--- a/modules/http4s/src/main/scala/natchez/http4s/NatchezMiddleware.scala
+++ b/modules/http4s/src/main/scala/natchez/http4s/NatchezMiddleware.scala
@@ -105,7 +105,7 @@ object NatchezMiddleware {
                       "client.http.uri"    -> req.uri.toString(),
                       "client.http.method" -> req.method.toString
                     )
-            reqʹ = req.putHeaders(knl.toHttp4sHeaders.headers)
+            reqʹ = req.withHeaders(knl.toHttp4sHeaders ++ req.headers) // prioritize request headers over kernel ones
             rsrc <- client.run(reqʹ).allocated
             _    <- Trace[F].put("client.http.status_code" -> rsrc._1.status.code.toString())
           } yield rsrc

--- a/modules/http4s/src/test/scala/natchez/http4s/InMemory.scala
+++ b/modules/http4s/src/test/scala/natchez/http4s/InMemory.scala
@@ -1,0 +1,92 @@
+// Copyright (c) 2021 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez.http4s
+
+import java.net.URI
+
+import cats.data.Chain
+import cats.effect.{ IO, Ref, Resource }
+import natchez.Kernel
+
+object InMemory {
+
+  class Span(
+    lineage : Lineage,
+    k       : Kernel,
+    ref     : Ref[IO, Chain[(Lineage, NatchezCommand)]]
+  ) extends natchez.Span[IO] {
+
+    def put(fields: (String, natchez.TraceValue)*): IO[Unit] =
+      ref.update(_.append(lineage -> NatchezCommand.Put(fields.toList)))
+
+    def kernel: IO[Kernel] =
+      ref.update(_.append(lineage -> NatchezCommand.AskKernel(k))).as(k)
+
+    def span(name: String): Resource[IO, natchez.Span[IO]] = {
+      val acquire = ref
+        .update(_.append(lineage -> NatchezCommand.CreateSpan(name)))
+        .as(new Span(lineage / name, k, ref))
+
+      val release = ref.update(_.append(lineage -> NatchezCommand.ReleaseSpan(name)))
+
+      Resource.make(acquire)(_ => release)
+    }
+
+    def traceId: IO[Option[String]] =
+      ref.update(_.append(lineage -> NatchezCommand.AskTraceId)).as(None)
+
+    def spanId: IO[Option[String]] =
+      ref.update(_.append(lineage -> NatchezCommand.AskSpanId)).as(None)
+
+    def traceUri: IO[Option[URI]] =
+      ref.update(_.append(lineage -> NatchezCommand.AskTraceUri)).as(None)
+  }
+
+  class EntryPoint(ref: Ref[IO, Chain[(Lineage, NatchezCommand)]]) extends natchez.EntryPoint[IO] {
+
+    def root(name: String): Resource[IO, Span] =
+      newSpan(name, Kernel(Map.empty))
+
+    def continue(name: String, kernel: Kernel): Resource[IO, Span] =
+      newSpan(name, kernel)
+
+    def continueOrElseRoot(name: String, kernel: Kernel): Resource[IO, Span] =
+      newSpan(name, kernel)
+
+    private def newSpan(name: String, kernel: Kernel): Resource[IO, Span] = {
+      val acquire = ref
+        .update(_.append(Lineage.Root -> NatchezCommand.CreateRootSpan(name, kernel)))
+        .as(new Span(Lineage.Root, kernel, ref))
+
+      val release = ref.update(_.append(Lineage.Root -> NatchezCommand.ReleaseRootSpan(name)))
+
+      Resource.make(acquire)(_ => release)
+    }
+  }
+
+  sealed trait Lineage {
+    def /(name: String): Lineage.Child = Lineage.Child(name, this)
+  }
+  object Lineage {
+    case object Root                                      extends Lineage
+    final case class Child(name: String, parent: Lineage) extends Lineage
+  }
+
+  sealed trait NatchezCommand
+  object NatchezCommand {
+    final case class AskKernel(kernel: Kernel)                       extends NatchezCommand
+    final case object AskSpanId                                      extends NatchezCommand
+    final case object AskTraceId                                     extends NatchezCommand
+    final case object AskTraceUri                                    extends NatchezCommand
+    final case class Put(fields: List[(String, natchez.TraceValue)]) extends NatchezCommand
+    final case class CreateSpan(name: String)                        extends NatchezCommand
+    final case class ReleaseSpan(name: String)                       extends NatchezCommand
+    // entry point
+    final case class CreateRootSpan(name: String, kernel: Kernel)    extends NatchezCommand
+    final case class ReleaseRootSpan(name: String)                   extends NatchezCommand
+  }
+
+}
+

--- a/modules/http4s/src/test/scala/natchez/http4s/InMemory.scala
+++ b/modules/http4s/src/test/scala/natchez/http4s/InMemory.scala
@@ -76,16 +76,16 @@ object InMemory {
 
   sealed trait NatchezCommand
   object NatchezCommand {
-    final case class AskKernel(kernel: Kernel)                       extends NatchezCommand
-    final case object AskSpanId                                      extends NatchezCommand
-    final case object AskTraceId                                     extends NatchezCommand
-    final case object AskTraceUri                                    extends NatchezCommand
-    final case class Put(fields: List[(String, natchez.TraceValue)]) extends NatchezCommand
-    final case class CreateSpan(name: String)                        extends NatchezCommand
-    final case class ReleaseSpan(name: String)                       extends NatchezCommand
+    case class AskKernel(kernel: Kernel)                       extends NatchezCommand
+    case object AskSpanId                                      extends NatchezCommand
+    case object AskTraceId                                     extends NatchezCommand
+    case object AskTraceUri                                    extends NatchezCommand
+    case class Put(fields: List[(String, natchez.TraceValue)]) extends NatchezCommand
+    case class CreateSpan(name: String)                        extends NatchezCommand
+    case class ReleaseSpan(name: String)                       extends NatchezCommand
     // entry point
-    final case class CreateRootSpan(name: String, kernel: Kernel)    extends NatchezCommand
-    final case class ReleaseRootSpan(name: String)                   extends NatchezCommand
+    case class CreateRootSpan(name: String, kernel: Kernel)    extends NatchezCommand
+    case class ReleaseRootSpan(name: String)                   extends NatchezCommand
   }
 
 }

--- a/modules/http4s/src/test/scala/natchez/http4s/NatchezMiddlewareSuite.scala
+++ b/modules/http4s/src/test/scala/natchez/http4s/NatchezMiddlewareSuite.scala
@@ -115,7 +115,7 @@ class NatchezMiddlewareSuite extends CatsEffectSuite {
     for {
       ref      <- IO.ref(Chain.empty[(Lineage, NatchezCommand)])
       ep       <- IO.pure(new InMemory.EntryPoint(ref))
-      routes   <- IO.pure(ep.liftT(httpRoutes[Kleisli[IO, natchez.Span[IO], *]], _ => false))
+      routes   <- IO.pure(ep.liftT(httpRoutes[Kleisli[IO, natchez.Span[IO], *]]))
       _        <- routes.orNotFound.run(request)
       history  <- ref.get
     } yield assertEquals(history.toList, expectedHistory)

--- a/modules/http4s/src/test/scala/natchez/http4s/NatchezMiddlewareSuite.scala
+++ b/modules/http4s/src/test/scala/natchez/http4s/NatchezMiddlewareSuite.scala
@@ -1,0 +1,150 @@
+// Copyright (c) 2021 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez.http4s
+
+import cats.Monad
+import cats.data.{ Chain, Kleisli }
+import cats.effect.{ IO, MonadCancelThrow, Resource }
+import munit.CatsEffectSuite
+import natchez.{Kernel, Trace}
+import natchez.TraceValue.StringValue
+import natchez.http4s.syntax.entrypoint._
+import org.http4s._
+import org.http4s.headers._
+import org.http4s.client.Client
+import org.http4s.dsl.request._
+import org.http4s.syntax.literals._
+import org.typelevel.ci._
+
+class NatchezMiddlewareSuite extends CatsEffectSuite {
+  import InMemory.{Lineage, NatchezCommand}
+
+  private val CustomHeaderName = ci"X-Custom-Header"
+  private val CorrelationIdName = ci"X-Correlation-Id"
+
+  test("do not leak security and payload headers to the client request") {
+    val headers = Headers(
+      // security
+      Authorization(BasicCredentials("username", "password")),
+      Cookie(RequestCookie("key", "value")),
+      `Set-Cookie`(ResponseCookie("key", "value")),
+      // payload
+      `Content-Type`(MediaType.`text/event-stream`),
+      `Content-Length`(42L),
+      `Content-Range`(1L),
+      Header.Raw(ci"Trailer", "Expires"),
+      `Transfer-Encoding`(TransferCoding.identity),
+      // custom conflicting (client uses this header)
+      Header.Raw(CustomHeaderName, "external"),
+      // custom non-conflicting
+      Header.Raw(CorrelationIdName, "id-123")
+    )
+
+    val request = Request[IO](
+      method = Method.GET,
+      uri = uri"/hello/some-name",
+      headers = headers
+    )
+
+    val expectedHeaders = Headers(
+      Header.Raw(CorrelationIdName, "id-123"),
+      Header.Raw(CustomHeaderName, "internal")
+    )
+
+    for {
+      ref      <- IO.ref(Chain.empty[(Lineage, NatchezCommand)])
+      ep       <- IO.pure(new InMemory.EntryPoint(ref))
+      routes   <- IO.pure(ep.liftT(httpRoutes[Kleisli[IO, natchez.Span[IO], *]]))
+      response <- routes.orNotFound.run(request)
+    } yield {
+      assertEquals(response.status.code, 200)
+      assertEquals(response.headers, expectedHeaders)
+    }
+  }
+
+  test("generate proper tracing history") {
+    val request = Request[IO](
+      method = Method.GET,
+      uri = uri"/hello/some-name",
+      headers = Headers(
+        Header.Raw(CustomHeaderName, "external"),
+        Header.Raw(CorrelationIdName, "id-123")
+      )
+    )
+
+    val expectedHistory = {
+      val requestKernel = Kernel(
+        Map("X-Custom-Header" -> "external", "X-Correlation-Id" -> "id-123")
+      )
+
+      val clientRequestTags = List(
+        "client.http.uri" -> StringValue("/some-name"),
+        "client.http.method" -> StringValue("GET")
+      )
+
+      val clientResponseTags = List(
+        "client.http.status_code" -> StringValue("200")
+      )
+
+      val requestTags = List(
+        "http.method" -> StringValue("GET"),
+        "http.url" -> StringValue("/hello/some-name")
+      )
+
+      val responseTags = List(
+        "http.status_code" -> StringValue("200")
+      )
+
+      List(
+        (Lineage.Root,                                          NatchezCommand.CreateRootSpan("/hello/some-name", requestKernel)),
+        (Lineage.Root,                                          NatchezCommand.CreateSpan("call-proxy")),
+        (Lineage.Root / "call-proxy",                           NatchezCommand.CreateSpan("http4s-client-request")),
+        (Lineage.Root / "call-proxy" / "http4s-client-request", NatchezCommand.AskKernel(requestKernel)),
+        (Lineage.Root / "call-proxy" / "http4s-client-request", NatchezCommand.Put(clientRequestTags)),
+        (Lineage.Root / "call-proxy" / "http4s-client-request", NatchezCommand.Put(clientResponseTags)),
+        (Lineage.Root / "call-proxy",                           NatchezCommand.ReleaseSpan("http4s-client-request")),
+        (Lineage.Root,                                          NatchezCommand.ReleaseSpan("call-proxy")),
+        (Lineage.Root,                                          NatchezCommand.Put(requestTags)),
+        (Lineage.Root,                                          NatchezCommand.Put(responseTags)),
+        (Lineage.Root,                                          NatchezCommand.ReleaseRootSpan("/hello/some-name"))
+      )
+    }
+
+    for {
+      ref      <- IO.ref(Chain.empty[(Lineage, NatchezCommand)])
+      ep       <- IO.pure(new InMemory.EntryPoint(ref))
+      routes   <- IO.pure(ep.liftT(httpRoutes[Kleisli[IO, natchez.Span[IO], *]], _ => false))
+      _        <- routes.orNotFound.run(request)
+      history  <- ref.get
+    } yield assertEquals(history.toList, expectedHistory)
+  }
+
+  private def httpRoutes[F[_]: MonadCancelThrow: Trace]: HttpRoutes[F] = {
+    val client = NatchezMiddleware.client(echoHeadersClient[F])
+    val server = NatchezMiddleware.server(proxyRoutes(client))
+    server
+  }
+
+  private def echoHeadersClient[F[_]: MonadCancelThrow]: Client[F] =
+    Client[F] { request =>
+      Resource.pure(Response[F](headers = request.headers))
+    }
+
+  private def proxyRoutes[F[_]: Monad: Trace](client: Client[F]): HttpRoutes[F] = {
+    HttpRoutes.of[F] {
+      case GET -> Root / "hello" / name =>
+        val request = Request[F](
+          method = Method.GET,
+          uri = Uri(path = Root / name),
+          headers = Headers(Header.Raw(CustomHeaderName, "internal"))
+        )
+
+        Trace[F].span("call-proxy") {
+          client.toHttpApp.run(request)
+        }
+    }
+  }
+
+}


### PR DESCRIPTION
When an HTTP call happens inside of the trace created by the HTTP request in `entryPoint.liftT`, some sensitive headers can be leaked.

Using `entryPoint.liftT` in combination with `NatchezMiddleware.client` leads to the following issues:
1) Client's request headers are overwritten by headers from Kernel https://github.com/tpolecat/natchez-http4s/blob/52cf5a6888100ee228952052b8206c01c59d2969/modules/http4s/src/main/scala/natchez/http4s/NatchezMiddleware.scala#L108

2) Headers from a server's request leaked to the downstream https://github.com/tpolecat/natchez-http4s/blob/52cf5a6888100ee228952052b8206c01c59d2969/modules/http4s/src/main/scala/natchez/http4s/syntax/EntryPointOps.scala#L32

### Example

```scala
val thirdPartyClient: Client[F] = NatchezMiddleware.client(???)

def verifyKey[F[_]](req: Request[F]) = req.headers.get("X-API-KEY").exists(...)
  
val serverRoutes: HttpRoutes[F] = HttpRoutes.of {
  case req @ GET -> Root / "find-file" / file if verifyKey(req) =>
    val request = Request[F](
       method = Method.GET,
       uri = "https://third-party.com/find-file" / file,
       headers = Headers(Header.Raw("X-Custom-Header", "internal"))
    )

    thirdPartyClient
      .run(request) // natchez middleware adds headers from kernel under the hood
      .flatMap(response => /* make response */)
}

val entryPoint: EntryPoint[IO] = ???
val server: HttpRoutes[IO] = entryPoint.liftT(serverRoutes)

val request = Request(
  GET, 
  "/find-file/file", 
  Headers(Headers.Raw("X-Custom-Header", "external"), Header.Raw("X-API-KEY", "secret"))
)

server.run(request) 
```

The headers present in Kernel have higher priority than the client request ones. That means, `Content-Type`, `Content-Length`, `Authorization`, and so on, are taken from the server request.

In the example above, `X-API-KEY` header is leaked to the third-party service, and the value of `X-Custom-Header` is `external` instead of `internal`.  

### The fix

I extended `liftT`, `liftR`, `wsLift`, `wsLiftR` methods with `isKernelHeader: CIString => Boolean` argument. 
And I covered this particular scenario with tests.

My changes are binary-breaking. Should I consider adding `ToEntryPointOpsBincompat` trait with new methods instead? 